### PR TITLE
derive tp53 copy number using user selected analysis bin size

### DIFF
--- a/scripts/ploidy_purity_search_standard_error.R
+++ b/scripts/ploidy_purity_search_standard_error.R
@@ -107,6 +107,54 @@ cntodepth<-function(cn,purity,seqdepth) #converts copy number to read depth give
     seqdepth*((1-purity)*2+purity*cn)
 }
 
+get_tp53_bin = function(bin_annotations, qdnaseq_object) {
+	# A function to determine the appropriate bin for TP53 in the human reference genome given a variable bin size
+	# input:
+	#	bin_annotations: genomic bin annotations for a given genome and bin size
+	#	qdnaseq_object: defines which to use, which is needed for bin indexing	
+	# output: The appropriate bin number for TP53 for the given bin annotations and qdnaseq object
+
+	# load in our table of bin co-ordinates. 'merged' refers to the fact that co-ordinate data and
+	# metadata is merged into a single column/variable and needs to be split
+	# Only used bins are processed in this step 
+	bin_coordinates = tibble::tibble(merged=rownames(bin_annotations[fData(qdnaseq_object[[1]])$use]))
+
+	# reformat bin co-ordinate data so 'merged' data column is split into meaningful constitutents
+	bin_coordinates = bin_coordinates %>% dplyr::mutate(
+		chromosome = stringr::str_split_fixed(merged, pattern=':', n=2)[,1],
+		locus = stringr::str_split_fixed(merged, pattern=':', n=2)[,2]	
+	) %>% dplyr::mutate(
+		start = stringr::str_split_fixed(locus, pattern='-', n=2)[,1],
+		stop = stringr::str_split_fixed(locus, pattern='-', n=2)[,2],
+		row_number = dplyr::row_number() # index each bin
+	)
+	# only select relevant columns
+	bin_coordinates = bin_coordinates %>% dplyr::select(row_number,chromosome,start,stop)
+
+	# derive the bin size from the precomputed bin annotations
+	bin_size = (bin_coordinates$stop[1] %>% as.integer - bin_coordinates$start[1] %>% as.integer) + 1	
+
+	# Data regarding the TP53 genomic co-ordinates hard-coded from Ensembl/Gencode
+	tp53 = tibble::tibble(chromosome=17, build='GRCh37', gencode_release_version=19, start=7565097, stop=7590856)
+	
+	# perform integer division of TP53 start with the bin size in order to determine the correct bin
+	# multiply the result of the integer division by the bin size to map the chosen bin back into genomic co-ordinates
+	tp53_segment_lower = ( tp53$start %/% bin_size ) * bin_size
+	tp53_segment_upper = tp53_segment_lower + bin_size 
+	tp53_segment_lower = tp53_segment_lower + 1 # this offset is needed by our bin reference table
+
+	# filter for TP53 bin
+	bin_coordinates = bin_coordinates %>% dplyr::filter(chromosome == tp53$chromosome[1]) %>%
+				dplyr::filter(start==tp53_segment_lower) %>%
+				dplyr::filter(stop==tp53_segment_upper)
+ 
+	# return bin number
+	return (bin_coordinates %>% .$row_number)
+} 
+
+# determine the correct tp53 bin index given the chosen bin size
+tp53_bin_index = get_tp53_bin(bins,rds.obj)
+
 #estimate absolute copy number fits for all samples in parallel
 ploidies<-seq(1.6,8,0.1)
 purities<-seq(0.05,1,0.01)
@@ -140,7 +188,7 @@ res<-foreach(i=1:length(ploidies),.combine=rbind) %do%
             integer_cn<-round(depthtocn(seg,purity,seqdepth))
             abs_cn<-depthtocn(seg,purity,seqdepth)
             diffs<-abs(abs_cn-integer_cn)
-            TP53cn<-round(depthtocn(seg[73504],purity,seqdepth),1) # to 1 decimal place
+            TP53cn<-round(depthtocn(seg[tp53_bin_index],purity,seqdepth),1) # to 1 decimal place
             expected_TP53_AF<-TP53cn*purity/(TP53cn*purity+2*(1-purity))
             clonality<-mean(diffs)
             c(ploidy,purity,clonality,downsample_depth,downsample_depth < rds.pdata$total.reads[row.names(rds.pdata)==sample],TP53cn,expected_TP53_AF)


### PR DESCRIPTION
This pull request references #9.

This code returns the same bin number for 30kb as that which was hard-coded into the script. I have tested this for 100kb and I am fairly confident that the bin number returned for 100kb is correct using this code.

Happy to modify code for style/neatness as well

I wrote this already so thought I would share if it saves people time - but obviously it is OK if you have written up your own solution for this